### PR TITLE
Fix: Make train departure checks timezone-aware to fix cleanup logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "cloud-sql-python-connector (>=1.18.2,<2.0.0)",
     "gunicorn (>=23.0.0,<24.0.0)",
     "sqlalchemy (>=2.0.0,<3.0.0)",
+    "pytz (>=2024.1,<2025.0)",
     "pg8000 (>=1.30.0,<2.0.0)",
     "gevent (>=24.0.0,<25.0.0)"
 ]


### PR DESCRIPTION
This commit resolves a bug where departed trains were not being cleaned up correctly from the tracking list.

The root cause was that the code was comparing a naive local departure time with the server's naive UTC time, leading to incorrect results.

The fix involves:
- Adding the `pytz` library to handle timezones.
- Updating both the manual cleanup function (`cleanup_expired_routes_db`) and the automatic cleanup in the `background_tracker` to use timezone-aware datetime objects. Departure times are now localized to 'Europe/Minsk' and compared against the current time in UTC, ensuring accurate detection of departed trains.