### PR TITLE
Fix: Prevent TypeError in timezone-aware datetime comparison

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1,6 +1,7 @@
 import calendar
 import logging
 from datetime import datetime, timedelta
+import pytz
 
 import requests
 from telebot import types
@@ -223,7 +224,7 @@ def check_tickets_by_class(train_number, soup, departure_datetime=None):
 
     no_seats_status = {"status": "Мест нет"}
     if departure_datetime:
-        time_diff = departure_datetime - datetime.now()
+        time_diff = departure_datetime - datetime.now(pytz.utc)
         if time_diff < timedelta(minutes=15):
             no_seats_status = {"status": "Продажа онлайн закрыта"}
 


### PR DESCRIPTION
This commit fixes a `TypeError: can't subtract offset-naive and offset-aware datetimes` that was introduced in the previous refactoring.

The error occurred in the `check_tickets_by_class` function because it was comparing a timezone-aware `departure_datetime` with a naive `datetime.now()`.

The fix is to use `datetime.now(pytz.utc)` in this function to ensure the comparison is always between two timezone-aware objects. This resolves the crash in the background worker.