### PR TITLE
Fix: Refactor departure time check to resolve TypeError

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -60,10 +60,10 @@ from src.database import (
 from src.utils import (  # get_proxies,; SiteResponseError,
     FutureDateError,
     PastDateError,
-    check_depart_time,
     check_tickets_by_class,
     generate_calendar,
     get_departure_datetime_from_soup,
+    has_departed,
     make_request,
     normalize_city_name,
     normalize_date,
@@ -574,7 +574,7 @@ def select_train(callback):
             reply_markup=markup,
         )
     # Проверка времени отправления
-    elif check_depart_time(train_selected, soup, train_id=None) <= 0:
+    elif has_departed(departure_datetime):
         btn_track = types.InlineKeyboardButton(
             "🔄 Назад к поездам",
             callback_data="re_get_trains_list",

--- a/src/utils.py
+++ b/src/utils.py
@@ -309,26 +309,13 @@ def get_departure_datetime_from_soup(train_number, soup, route_date):
         return None
 
 
-def check_depart_time(train_number, soup, train_id):
-    # информация о наличии мест и классов вагонов
-    train_info = soup.select(
-        f'div.sch-table__row[data-train-number^="{train_number}"] \
-            div.sch-table__time.train-from-time'
-    )
-    logging.info(
-        f"FG check_depart_time (train_number, train_id, train_info) \n"
-        f"{train_number, ' ',  train_id, '\n', train_info}"
-    )
-
-    depart_time = get_departure_date_db(train_id) if train_id else None
-    today = datetime.today().date()
-
-    if not train_info and depart_time and (depart_time >= today):
-        raise SiteResponseError('Ошибка получения данных поезда с сайта')
-    elif not train_info and depart_time and depart_time < today:
-        result = 0
-    elif not train_info:
-        result = 0
-    else:
-        result = int(train_info[0]["data-value"])
-    return result
+def has_departed(departure_datetime):
+    """
+    Checks if a timezone-aware departure datetime is in the past.
+    Returns True if the train has departed, False otherwise.
+    """
+    if not departure_datetime:
+        # If we don't have a departure time, assume it hasn't departed
+        # to prevent accidentally removing it.
+        return False
+    return departure_datetime < datetime.now(pytz.utc)


### PR DESCRIPTION
This commit fixes a `TypeError: can't subtract offset-naive and offset-aware datetimes` that was occurring in the `select_train` callback handler.

The `check_depart_time` function has been replaced with a new, simpler `has_departed` function. This new function takes a timezone-aware datetime object and correctly compares it against the current UTC time.

The `select_train` function has been updated to use this new helper, which makes the time-checking logic consistent across the application and resolves the crash.