### PR TITLE
Fix: Ensure get_departure_datetime_from_soup returns an aware datetime

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -303,7 +303,10 @@ def get_departure_datetime_from_soup(train_number, soup, route_date):
         if isinstance(route_date, str):
             route_date = datetime.strptime(route_date, "%Y-%m-%d").date()
 
-        return datetime.combine(route_date, departure_time)
+        naive_departure = datetime.combine(route_date, departure_time)
+        minsk_tz = pytz.timezone('Europe/Minsk')
+        aware_departure = minsk_tz.localize(naive_departure)
+        return aware_departure
     except (AttributeError, ValueError) as e:
         logging.warning(f"Could not parse departure datetime for train {train_number} from soup: {e}")
         return None


### PR DESCRIPTION
This commit provides a critical fix to the `get_departure_datetime_from_soup` helper function.

The function was previously returning a timezone-naive datetime object. This caused a `TypeError` downstream when this naive object was compared with timezone-aware datetime objects.

The function has been modified to localize the created datetime to the 'Europe/Minsk' timezone, ensuring it always returns a timezone-aware object. This resolves the `TypeError` crash in the `select_train` callback handler.