### PR TITLE
Feat: Add proxy support and threading to resolve blocking issues

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -376,17 +376,19 @@ def get_date(message):
 
 
 # Функция получения поездов по маршруту
-def get_trains_list(message):
-    # Для отображения активности
-    bot.send_chat_action(message.chat.id, 'typing')  # Show typing indicator
-    time.sleep(1)  # Optional delay
-    bot.send_message(message.chat.id, "Идёт поиск 🔍")  # Send your custom text
+def process_get_trains_list(message):
+    # For a more responsive feel, send the "typing" action from the main thread.
+    # The user already sees "Идёт поиск 🔍", so this might be redundant.
+    # bot.send_chat_action(message.chat.id, 'typing')
+    # time.sleep(1)
+
     chat_id = message.chat.id
     logging.debug(f"FLAG start 1 get_trains_list {''}")
     user_info = get_user_data(chat_id)
     if not user_info:
         logging.error(f"No user data for chat_id {chat_id}")
-        raise ValueError("User data not found")
+        # Cannot raise an exception in a thread, so just return
+        return
 
     try:
         q_from = quote(user_info["city_from"])
@@ -394,7 +396,8 @@ def get_trains_list(message):
         date = user_info["date"]
     except KeyError as e:
         logging.error(f"Missing key in user data: {e}")
-        raise ValueError(f"Incomplete user data: missing {e}")
+        # Cannot raise, so just return
+        return
 
     # Получение новой страницы "soup"
     url = f"https://pass.rw.by/ru/route/?from={q_from}&to={q_to}&date={date}"
@@ -483,6 +486,16 @@ def get_trains_list(message):
         )
         start(message)
         return
+
+
+def get_trains_list(message):
+    # This function is now fast. It just sends a message and starts a thread.
+    bot.send_chat_action(message.chat.id, 'typing')
+    bot.send_message(message.chat.id, "Идёт поиск 🔍")
+
+    # Start a new thread to handle the slow processing
+    thread = threading.Thread(target=process_get_trains_list, args=(message,))
+    thread.start()
 
 
 @ensure_start

--- a/src/utils.py
+++ b/src/utils.py
@@ -8,7 +8,7 @@ from telebot import types
 
 from all_stations_list import all_station_list, all_station_list_lower
 
-# from src.config import settings
+from src.config import settings
 from src.database import get_departure_date_db
 
 
@@ -288,7 +288,15 @@ def make_request(url):
             "X-Requested-With": "XMLHttpRequest",
         }
     )
-    r = session.get(url, timeout=30)
+
+    proxies = None
+    if settings.PROXY_URL:
+        proxies = {
+            "http": settings.PROXY_URL,
+            "https": settings.PROXY_URL,
+        }
+
+    r = session.get(url, timeout=30, proxies=proxies)
     r.raise_for_status()  # Raise an exception for bad status codes
     return r
 


### PR DESCRIPTION
This commit introduces two major architectural changes to handle IP blocks from the target website and to prevent UI timeouts.

1.  **Proxy Support:** The `make_request` function has been updated to use a proxy server if a `PROXY_URL` is provided in the configuration. This is necessary to bypass IP-based blocking from the target website.

2.  **Non-Blocking Train Search:** The `get_trains_list` function has been refactored to be non-blocking. It now starts a new thread to perform the slow web scraping, which prevents the Telegram API from timing out and causing a "query is too old" error.