### PR TITLE
Fix: Update poetry.lock to resolve build failure

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1682,6 +1682,18 @@ socks = ["httpx[socks]"]
 webhooks = ["tornado (>=6.2,<7.0)"]
 
 [[package]]
+name = "pytz"
+version = "2024.2"
+description = "World timezone definitions, modern and historical"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "pytz-2024.2-py2.py3-none-any.whl", hash = "sha256:31c7c1817eb7fae7ca4b8c7ee50c72f93aa2dd863de768e1ef4245d426aa0725"},
+    {file = "pytz-2024.2.tar.gz", hash = "sha256:2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a"},
+]
+
+[[package]]
 name = "requests"
 version = "2.32.3"
 description = "Python HTTP for Humans."
@@ -2141,4 +2153,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "6eb9ee34baeda312c48f78eb366c43d3caf6ab203b418daf85cad27d7f3e02a9"
+content-hash = "130a3d969119d2c31d30172122698dd0a88cb757e67ca2211fe748ddf1720eaf"


### PR DESCRIPTION
This commit updates the `poetry.lock` file to be consistent with the `pyproject.toml` file after the `pytz` library was added as a dependency.

This resolves the build failure in Cloud Build that was caused by the lock file being out of sync with the project's dependencies.