### PR TITLE
Feat: Add diagnostic logging for proxy URL

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -274,6 +274,9 @@ def get_tickets_by_class(train_info):
 
 def make_request(url):
     """Creates a requests session and makes a GET request."""
+    # Diagnostic logging to check if the proxy URL is being loaded
+    logging.info(f"Attempting request with PROXY_URL: '{settings.PROXY_URL}'")
+
     session = requests.Session()
     session.headers.update(
         {


### PR DESCRIPTION
This commit adds a debug logging statement to the `make_request` function.

This log will print the value of the `PROXY_URL` setting as seen by the application at runtime. This will help diagnose why the proxy is not being used, even when the secret appears to be set correctly.